### PR TITLE
feat(pki): add support of flatten rdn structure

### DIFF
--- a/packages/supervisor/src/pki/pkijs/rdn.ts
+++ b/packages/supervisor/src/pki/pkijs/rdn.ts
@@ -1,0 +1,28 @@
+import { RelativeDistinguishedNames } from "@yonagi/common/types/pki/RelativeDistinguishedNames"
+import * as asn1js from "asn1js"
+import * as pkijs from "pkijs"
+
+import { OID_CommonName, OID_OrganizationName } from "../consts"
+
+export class ExtendedRelativeDistinguishedNames extends pkijs.RelativeDistinguishedNames {
+    toSchema(): asn1js.Sequence {
+        return new asn1js.Sequence({
+            value: Array.from(this.typesAndValues, (element) => new asn1js.Set({ value: [element.toSchema()] })),
+        })
+    }
+}
+
+export function convertRdnToPkijsRdn(rdn: RelativeDistinguishedNames): ExtendedRelativeDistinguishedNames {
+    return new ExtendedRelativeDistinguishedNames({
+        typesAndValues: [
+            new pkijs.AttributeTypeAndValue({
+                type: OID_CommonName,
+                value: new asn1js.BmpString({ value: rdn.commonName }),
+            }),
+            new pkijs.AttributeTypeAndValue({
+                type: OID_OrganizationName,
+                value: new asn1js.BmpString({ value: rdn.organizationName }),
+            }),
+        ],
+    })
+}

--- a/packages/supervisor/src/pki/pkijs/rdn.ts
+++ b/packages/supervisor/src/pki/pkijs/rdn.ts
@@ -17,11 +17,11 @@ export function convertRdnToPkijsRdn(rdn: RelativeDistinguishedNames): ExtendedR
         typesAndValues: [
             new pkijs.AttributeTypeAndValue({
                 type: OID_CommonName,
-                value: new asn1js.BmpString({ value: rdn.commonName }),
+                value: new asn1js.PrintableString({ value: rdn.commonName }),
             }),
             new pkijs.AttributeTypeAndValue({
                 type: OID_OrganizationName,
-                value: new asn1js.BmpString({ value: rdn.organizationName }),
+                value: new asn1js.PrintableString({ value: rdn.organizationName }),
             }),
         ],
     })

--- a/packages/supervisor/src/pki/pkijs/utils.ts
+++ b/packages/supervisor/src/pki/pkijs/utils.ts
@@ -6,7 +6,7 @@ import * as pkijs from "pkijs"
 
 import { PkijsCertificate } from "."
 import { CryptoEngineShim } from "./cryptoEngine"
-import { convertRdnToPkijsRdn } from "./rdn"
+import { ExtendedRelativeDistinguishedNames, convertRdnToPkijsRdn } from "./rdn"
 import { CreateCertificateProps, ExtendedKeyUsages, KeyUsages } from ".."
 import { OID_ClientAuth, OID_CommonName, OID_KP_EapOverLan, OID_OrganizationName, OID_ServerAuth } from "../consts"
 
@@ -117,7 +117,9 @@ export async function createCertificate(
         if (!(issuer instanceof PkijsCertificate)) {
             throw new Error("Cannot derive issuer's subject from non-Pkijs certificate factory")
         }
-        cert.issuer = issuer.pkijsCertificate.subject
+        cert.issuer = new ExtendedRelativeDistinguishedNames({
+            typesAndValues: issuer.pkijsCertificate.subject.typesAndValues,
+        })
     } else {
         cert.issuer = cert.subject
     }

--- a/packages/supervisor/src/pki/pkijs/utils.ts
+++ b/packages/supervisor/src/pki/pkijs/utils.ts
@@ -6,6 +6,7 @@ import * as pkijs from "pkijs"
 
 import { PkijsCertificate } from "."
 import { CryptoEngineShim } from "./cryptoEngine"
+import { convertRdnToPkijsRdn } from "./rdn"
 import { CreateCertificateProps, ExtendedKeyUsages, KeyUsages } from ".."
 import { OID_ClientAuth, OID_CommonName, OID_KP_EapOverLan, OID_OrganizationName, OID_ServerAuth } from "../consts"
 
@@ -61,21 +62,6 @@ function createKeyUsageExt(keyUsages: KeyUsages): pkijs.Extension {
         critical: true,
         extnValue: keyUsage.toBER(false),
         parsedValue: keyUsage,
-    })
-}
-
-function convertRdnToPkijsRdn(rdn: RelativeDistinguishedNames): pkijs.RelativeDistinguishedNames {
-    return new pkijs.RelativeDistinguishedNames({
-        typesAndValues: [
-            new pkijs.AttributeTypeAndValue({
-                type: OID_CommonName,
-                value: new asn1js.BmpString({ value: rdn.commonName }),
-            }),
-            new pkijs.AttributeTypeAndValue({
-                type: OID_OrganizationName,
-                value: new asn1js.BmpString({ value: rdn.organizationName }),
-            }),
-        ],
     })
 }
 


### PR DESCRIPTION
Creating a more compatible RelativeDistinguishedNames, which replacing one set of multiple DN elements with individual sets for each element by overriding serialization.

Fix #19.

_The solution is originally posted by @YuryStrozhevsky in https://github.com/PeculiarVentures/PKI.js/issues/169#issuecomment-384174083_